### PR TITLE
Adding sentry tracking

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -60,7 +60,6 @@ module.exports = {
           // htaccess_user: 'your-htaccess-username',
           // htaccess_pass: 'your-htaccess-password',
           // htaccess_sendImmediately: false,
-
           // If hostingWPCOM is true then you will need to communicate with wordpress.com API
           // in order to do that you need to create an app (of type Web) at https://developer.wordpress.com/apps/
           // then add your clientId, clientSecret, username, and password here
@@ -86,11 +85,23 @@ module.exports = {
         // See: https://github.com/isaacs/minimatch
         // Example:  `["/*/*/comments", "/yoast/**"]` will exclude routes ending in `comments` and
         // all routes that begin with `yoast` from fetch.
-        excludedRoutes: ['/*/*/comments', '/yoast/**', '/oembed/**', '/**/users/**', '/**/comments/**'],
+        excludedRoutes: [
+          '/*/*/comments',
+          '/yoast/**',
+          '/oembed/**',
+          '/**/users/**',
+          '/**/comments/**',
+        ],
         // use a custom normalizer which is applied after the built-in ones.
         normalizer: function({ entities }) {
           return entities;
         },
+      },
+    },
+    {
+      resolve: 'gatsby-plugin-sentry',
+      options: {
+        dsn: 'https://314dbec933e44245ae35b28fcb15bc96@sentry.io/1289118'
       },
     },
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -8923,6 +8923,14 @@
         "@babel/runtime": "^7.0.0"
       }
     },
+    "gatsby-plugin-sentry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-sentry/-/gatsby-plugin-sentry-0.1.0.tgz",
+      "integrity": "sha512-DGyIAq8p+IpsyOaAduxzCdLX/aTQVP4vVVlWbCCa31n+LRMAISwKtifm0TZEcgyYOarg3YJwP8D0jrmdoG4HDg==",
+      "requires": {
+        "raven-js": "^3.27.0"
+      }
+    },
     "gatsby-plugin-typescript": {
       "version": "2.0.0-rc.6",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-typescript/-/gatsby-plugin-typescript-2.0.0-rc.6.tgz",
@@ -15078,6 +15086,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+    },
+    "raven-js": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.27.0.tgz",
+      "integrity": "sha512-vChdOL+yzecfnGA+B5EhEZkJ3kY3KlMzxEhShKh6Vdtooyl0yZfYNFQfYzgMf2v4pyQa+OTZ5esTxxgOOZDHqw=="
     },
     "raw-body": {
       "version": "2.3.2",

--- a/package.json
+++ b/package.json
@@ -75,15 +75,16 @@
     "gatsby-plugin-manifest": "^2.0.2",
     "gatsby-plugin-offline": "^2.0.0",
     "gatsby-plugin-react-helmet": "^3.0.0",
+    "gatsby-plugin-sentry": "^0.1.0",
     "gatsby-plugin-typescript": "next",
     "gatsby-source-filesystem": "^2.0.1",
     "gatsby-source-wordpress": "^3.0.1",
     "gatsby-transformer-remark": "^2.1.3",
+    "moment": "^2.22.2",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
     "react-helmet": "^5.2.0",
-    "rehype-react": "^3.0.3",
-    "moment": "^2.22.2"
+    "rehype-react": "^3.0.3"
   },
   "jest": {
     "transform": {


### PR DESCRIPTION
Added two-way Sentry integration.

 - Project now reports issues to sentry (this occurs only when using `gatsby build` not `gatsby develop`)
 - Sentry tracks project commits and can identify when it suspects a bug is tied to a release.

This closes https://github.com/KomodoHQ/komododigital.co.uk-frontend/issues/21 