### PR TITLE
Add pagination to the insights page

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -48,6 +48,28 @@ exports.createPages = ({ graphql, actions }) => {
       // Templates are prefixed with underscore
       const blogPostTemplate = path.resolve('./src/pages/_blog.tsx');
       const caseStudyTemplate = path.resolve('./src/pages/_client-story.tsx');
+
+      // Create a page for every 21 blog posts.
+      // This sets up pagination allowing all blog posts to be viewed
+      const posts = result.data.allWordpressPost.edges;
+      const postsPerPage = 21;
+      const totalArticles = posts.length;
+      const numPages = Math.ceil(totalArticles / postsPerPage);
+
+      Array.from({length: numPages}).forEach((edge, index) => {
+        createPage({
+          path: index === 0 ? `/insights` : `/insights/${index}/`,
+          component: path.resolve('./src/pages/insights.tsx'),
+          context: {
+            limit: postsPerPage,
+            skip: index * postsPerPage,
+            numPages,
+            totalArticles,
+            nextPage: index + 1,
+          },
+        });
+      });
+
       // We want to create a detailed page for each
       // post node. We'll just use the WordPress Slug for the slug.
       // The Post ID is prefixed with 'POST_'

--- a/src/components/centercontent/centercontent.css
+++ b/src/components/centercontent/centercontent.css
@@ -1,5 +1,9 @@
 @import '../settings.css';
 
+.centercontent-wrapper {
+    padding: 260px 0;
+}
+
 .CenterContent {
     grid-column: 3 / 15;
 }

--- a/src/components/centercontent/centercontent.css
+++ b/src/components/centercontent/centercontent.css
@@ -1,9 +1,5 @@
 @import '../settings.css';
 
-.centercontent-wrapper {
-    padding: 260px 0;
-}
-
 .CenterContent {
     grid-column: 3 / 15;
 }
@@ -84,27 +80,27 @@
     .centercontent-wrapper.topPaddingLarge {
         padding-top: 180px;
     }
-    
+
     .centercontent-wrapper.topPaddingMedium {
         padding-top: 120px;
     }
-    
+
     .centercontent-wrapper.topPaddingSmall {
         padding-top: 60px;
     }
-    
+
     .centercontent-wrapper.bottomPaddingLarge {
         padding-bottom: 180px;
     }
-    
+
     .centercontent-wrapper.bottomPaddingMedium {
         padding-bottom: 120px;
     }
-    
+
     .centercontent-wrapper.bottomPaddingSmall {
         padding-bottom: 60px;
     }
-    
+
 
 }
 
@@ -129,7 +125,7 @@
     .Content-Section > div {
         grid-column: 8/17;
     }
-    
+
     .centercontent-wrapper.topPaddingExtraLarge {
         padding-top: 180px;
     }
@@ -137,23 +133,23 @@
     .centercontent-wrapper.topPaddingLarge {
         padding-top: 180px;
     }
-    
+
     .centercontent-wrapper.topPaddingMedium {
         padding-top: 120px;
     }
-    
+
     .centercontent-wrapper.topPaddingSmall {
         padding-top: 60px;
     }
-    
+
     .centercontent-wrapper.bottomPaddingLarge {
         padding-bottom: 180px;
     }
-    
+
     .centercontent-wrapper.bottomPaddingMedium {
         padding-bottom: 120px;
     }
-    
+
     .centercontent-wrapper.bottomPaddingSmall {
         padding-bottom: 60px;
     }

--- a/src/components/seemorebutton/index.tsx
+++ b/src/components/seemorebutton/index.tsx
@@ -15,24 +15,26 @@ import './seemorebutton.css';
 
 /**
  * Props for the see more button component
- * 
+ *
  * data
  */
 interface Props {
   title: string;
   link?: string;
+  className?: string;
+  disabled?: boolean;
 }
 
 /**
- * 
+ *
  * Using SFC (Stateless Functional Component) because a see more button doesn't need to maintain any state of its own.
- * 
+ *
  * @param data
  */
-const SeeMoreButton: React.SFC<Props> = ({ title, link="/About" }) => {
+const SeeMoreButton: React.SFC<Props> = ({ title, link = '/About', className, disabled = false }) => {
   return (
-    <div className="komodoGridWrapper seemorebutton-wrapper">
-        <Link to={link}><button>{title}</button></Link>
+    <div className={`komodoGridWrapper seemorebutton-wrapper ${className}`}>
+        <Link to={link}><button disabled={disabled}>{title}</button></Link>
     </div>
   );
 };

--- a/src/components/seemorebutton/seemorebutton.css
+++ b/src/components/seemorebutton/seemorebutton.css
@@ -11,9 +11,15 @@
     transition: all 0.2s ease;
 }
 
-.seemorebutton-wrapper > a :hover {
+.seemorebutton-wrapper > a :hover:enabled {
     transform: translateY(-2px);
     box-shadow: 0 10px 20px 0 rgba(0,0,0,0.2);
+    cursor: pointer;
+}
+
+.seemorebutton-wrapper > a :disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
 }
 
 .seemorebutton-wrapper > a > button {
@@ -24,6 +30,14 @@
     color: white;
     padding: 25px 75px;
     letter-spacing: 1px;
+}
+
+.seemorebutton-wrapper.topPaddingSmall {
+    padding-top: 30px
+}
+
+.seemorebutton-wrapper.bottomPaddingMedium {
+    padding-bottom: 60px
 }
 
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -19,13 +19,13 @@ export default (props) => {
   const testimonial = findNodeRaw('client-stories/onward/testimonial', props.data.testimonial);
 
   const insights = props.data.allWordpressPost.edges.map((edge) => {
-    const data = {
+    const media = edge.node.featured_media;
+    return {
       node: {
-        imageSource: CleanSourceURL(edge.node.featured_media.source_url),
+        imageSource: media === null ? '' : CleanSourceURL(media.source_url),
         ...edge.node,
       },
     };
-    return data;
   });
 
   const hocProps = {

--- a/src/pages/insights.tsx
+++ b/src/pages/insights.tsx
@@ -7,14 +7,13 @@ import { findNodes, findNode } from '../utils/nodes';
 
 export default (props) => {
   const posts = props.data.allWordpressPost.edges.map((edge) => {
-    const data = {
+    const media = edge.node.featured_media;
+    return {
       node: {
-        imageSource: CleanSourceURL(edge.node.featured_media.source_url),
+        imageSource: media === null ? '' : CleanSourceURL(media.source_url),
         ...edge.node,
       },
     };
-
-    return data;
   });
 
   const insightsIntro = findNode('insights/index', props);
@@ -28,7 +27,7 @@ export default (props) => {
 };
 
 export const blogListQuery = graphql`
-  query blogListQuery {
+  query blogListQuery($limit: Int, $skip: Int) {
     ...siteMeta
     allMarkdownRemark(filter: { fileAbsolutePath: { regex: "/insights/" } }) {
       edges {
@@ -50,7 +49,7 @@ export const blogListQuery = graphql`
         }
       }
     }
-    allWordpressPost(limit: 20) {
+    allWordpressPost(limit: $limit, skip: $skip) {
       edges {
         node {
           status

--- a/src/templates/insights.tsx
+++ b/src/templates/insights.tsx
@@ -4,12 +4,31 @@ import Layout from '../components/layout';
 import TitleText from '../components/titletext';
 import BlogGrid from '../components/bloggrid';
 import BlogPost from '../components/blogpost';
+import SeeMoreButton from '../components/seemorebutton';
+import CenterContent from '../components/centercontent';
 
 const renderAst = new rehypeReact({
   createElement: React.createElement,
 }).Compiler;
 
 export default (props) => {
+  const { nextPage, totalArticles, numPages } = props.pageContext;
+  const lastPage = numPages === nextPage;
+  const viewedArticles = lastPage ? (totalArticles % 21) + (nextPage - 1) * 21 : (nextPage) * 21;
+
+  const styles = {
+    progress: {
+      width: '35%',
+      backgroundColor: '#d8d8d8',
+      margin: 'auto',
+    },
+    bar: {
+      height: 8,
+      backgroundColor: 'black',
+      width: `${(viewedArticles / totalArticles) * 100}%`,
+    },
+  };
+
   return (
     <Layout data={props.data} inverted={true} background="#EAEAEA">
       <TitleText
@@ -32,6 +51,15 @@ export default (props) => {
           );
         })}
       </BlogGrid>
+      <CenterContent>
+        <p style={{ textAlign: 'center' }}>
+          You've viewed {viewedArticles} of {totalArticles} articles
+          <div style={styles.progress}>
+              <div style={styles.bar}></div>
+          </div>
+        </p>
+      </CenterContent>
+      <SeeMoreButton className={'topPaddingSmall bottomPaddingMedium'} title="See More Insights" link={`insights/${nextPage}`} disabled={lastPage} />
     </Layout>
   );
 };

--- a/src/templates/insights.tsx
+++ b/src/templates/insights.tsx
@@ -51,7 +51,7 @@ export default (props) => {
           );
         })}
       </BlogGrid>
-      <CenterContent>
+      <CenterContent className={'topPaddingNone bottomPaddingNone'}>
         <p style={{ textAlign: 'center' }}>
           You've viewed {viewedArticles} of {totalArticles} articles
           <div style={styles.progress}>


### PR DESCRIPTION
Currently only 20 insights are returned. This PR will change this to return 21 per page, and allow you to "load more" which will take you to the next page.