### PR TITLE
Ensure that images are not exceeding the containers width 

### DIFF
--- a/src/components/centercontent/centercontent.css
+++ b/src/components/centercontent/centercontent.css
@@ -71,6 +71,11 @@
     padding-bottom: 0;
 }
 
+img {
+    max-width: 100%;
+    height: auto;
+}
+
 @media (--mobile-viewport) {
 
     .CenterContent .gatsby-resp-image-link {


### PR DESCRIPTION
Currently images can exceed the containers width causing styling issues with blog posts on mobile devices.