### PR TITLE
Fix navigation bar on mobile

### DIFF
--- a/src/components/navigationbar/NavigationBar.css
+++ b/src/components/navigationbar/NavigationBar.css
@@ -153,6 +153,10 @@
         text-decoration: none;
         font-size: 16px;
     }
+
+    .navigationBar.small > ul > li > a {
+        font-size: 15px;
+    }
 /*
     .navigationBar.small img {
         max-width: 135px;
@@ -167,6 +171,10 @@
         font-size: 22px;
     }
 
+    .navigationBar.small > ul > li > a {
+        font-size: 20px;
+    }
+
 }
 
 @media (--desktop-viewport) {
@@ -177,5 +185,9 @@
 
     .navigationBar > ul {
         grid-column: 9 / 16;
+    }
+
+    .navigationBar.small > ul > li > a {
+        font-size: 20px;
     }
 }


### PR DESCRIPTION
Currently the navbar on mobile does not resize correctly on mobile devices and the list elements are squished together. This PR fixes this by using a smaller font size on mobile devices.