### PR TITLE
Fixed default link on SeeMoreButton component to use 'about' instead …

### DIFF
--- a/src/components/seemorebutton/index.tsx
+++ b/src/components/seemorebutton/index.tsx
@@ -31,7 +31,7 @@ interface Props {
  *
  * @param data
  */
-const SeeMoreButton: React.SFC<Props> = ({ title, link = '/About', className, disabled = false }) => {
+const SeeMoreButton: React.SFC<Props> = ({ title, link = '/about', className, disabled = false }) => {
   return (
     <div className={`komodoGridWrapper seemorebutton-wrapper ${className}`}>
         <Link to={link}><button disabled={disabled}>{title}</button></Link>


### PR DESCRIPTION
Fixed default link on SeeMoreButton component to use 'about' instead of 'About' (changed to use lowercase A) to prevent 404.

Steps to reproduce: 
- Click 'Client Stories'
- Click 'Read Case Study' on any item
- Scroll down to bottom of page
- Click 'See More Work' button
- Get 404 error
