### PR TITLE
Do not escape blog post titles

### DIFF
--- a/src/components/titletext/index.tsx
+++ b/src/components/titletext/index.tsx
@@ -54,7 +54,7 @@ const TitleText: React.SFC<Props> = ({
   imageOverlap = false,
 }) => {
   const subtitleEl = subtitle ? <span>{subtitle}</span> : null;
-  const titleEl = title ? <h2>{title}</h2> : null;
+  const titleEl = title ? <h2 dangerouslySetInnerHTML={{ __html: title }}></h2> : null;
   const invertedClassname = invert ? 'invert' : '';
 
   let style = {


### PR DESCRIPTION
Blog titles are being escaped currently causing things such as `&#8217;` to be rendered.