### PR TITLE
KOM-16/KOM-17 - Unique title and meta descriptions

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -6,26 +6,37 @@ import LegalFooter from './legalfooter';
 import '../assets/css/cookies.css';
 import './layout.css';
 import Img from 'gatsby-image';
+import { PageMeta } from './seo/types';
 
 interface Props {
   children?: ReactNode;
   data?: any;
+  pageMeta?: PageMeta;
   background?: string;
   inverted?: boolean;
 }
 
-const Layout: React.SFC<Props> = ({ data, children, background = '', inverted = false }) => {
+const Layout: React.SFC<Props> = ({
+  data,
+  pageMeta,
+  children,
+  background = '',
+  inverted = false,
+}) => {
   const logo = !inverted ? data.logo.childImageSharp : data.logo_inverted.childImageSharp;
+
+  const title = (pageMeta && pageMeta.title) || '';
+  const description = (pageMeta && pageMeta.description) || data.site.siteMetadata.description;
 
   return (
     <>
       <SEO
         defaultTitle={data.site.siteMetadata.title}
         siteName={data.site.siteMetadata.name}
-        description={data.site.siteMetadata.description}
+        description={description}
         // TODO: fix
         url="http://test"
-        // TODO: Individual page title
+        title={title}
       >
         <meta
           name="google-site-verification"

--- a/src/components/seo/types.ts
+++ b/src/components/seo/types.ts
@@ -1,0 +1,4 @@
+export interface PageMeta {
+  title: string;
+  description: string;
+}

--- a/src/content/about/index.md
+++ b/src/content/about/index.md
@@ -3,6 +3,8 @@ title: 'Values and Culture Delivering Exceptional Outcomes'
 subtitle: 'The Why Behind The How'
 date: '2018-09-22'
 csimage: '../images/about/about-img@3x.png'
+metaTitle: 'About' # TODO: Review meta title
+metaDescription: '' # TODO: Review meta description
 ---
 
 We believe digital products that deliver significant positive impact are created when there is a strong alignment of culture and values within and between the teams that build them.

--- a/src/content/client-stories/gichd/index.md
+++ b/src/content/client-stories/gichd/index.md
@@ -10,6 +10,8 @@ navBackground: '#D17C2F'
 background: 'linear-gradient(0deg, #D17C2F 0%, #D17C2F 100%)'
 invert: true
 excerpt: 'Komodo was chosen to partner with the Geneva International Centre for Humanitarian Demining (GICHD) in the development of a tablet version of their entire Ammunition Safety Management (ASM) Toolset.'
+# metaTitle: '' # TODO: Review meta title - will use value of 'title' if not set
+# metaDescription: '' # TODO: Review meta description - will use value of 'excerpt' if not set
 ---
 
 Komodo was chosen to partner with the Geneva International Centre for Humanitarian Demining (GICHD) in the development of a tablet version of their entire Ammunition Safety Management (ASM) Toolset.

--- a/src/content/client-stories/index.md
+++ b/src/content/client-stories/index.md
@@ -1,6 +1,8 @@
 ---
 title: 'Client Stories'
 date: '2018-09-22'
+metaTitle: 'Client Stories' # TODO: Review meta title
+# metaDescription: '' # TODO: Review meta description
 ---
 
 We love success stories. Here are a few that we have helped create.

--- a/src/content/client-stories/itv/index.md
+++ b/src/content/client-stories/itv/index.md
@@ -10,6 +10,8 @@ navBackground: '#DB8484'
 background: 'linear-gradient(0deg, #DB8484 0%, #DB8484 100%)'
 invert: true
 excerpt: 'Signed Stories is an award-winning iPhone and iPad application, designed and developed for ITV SignPost by Komodo Digital and published by ITV Broadcasting Limited.'
+# metaTitle: '' # TODO: Review meta title - will use value of 'title' if not set
+# metaDescription: '' # TODO: Review meta description - will use value of 'excerpt' if not set
 ---
 
 Signed Stories is an award-winning iPhone and iPad application, designed and developed for ITV SignPost by Komodo Digital and published by ITV Broadcasting Limited.

--- a/src/content/client-stories/northumbria-police/index.md
+++ b/src/content/client-stories/northumbria-police/index.md
@@ -10,6 +10,8 @@ navBackground: '#171717'
 background: 'linear-gradient(0deg, #171717 0%, #171717 100%)'
 invert: true
 excerpt: 'Police E-Box is a multi-phased project that sees the integration of mobile technology into police officers day to day workflow, streamlining access to information and reducing load on resource control and radio...'
+# metaTitle: '' # TODO: Review meta title - will use value of 'title' if not set
+# metaDescription: '' # TODO: Review meta description - will use value of 'excerpt' if not set
 ---
 
 Police E-Box is a multi-phased project that sees the integration of mobile technology into police officers day to day workflow, streamlining access to information and reducing load on resource control and radio channels via smartphone technology.

--- a/src/content/client-stories/onward/index.md
+++ b/src/content/client-stories/onward/index.md
@@ -10,6 +10,8 @@ navBackground: '#0E1948'
 background: 'linear-gradient(0deg, #0E1948 0%, #0E1948 100%)'
 invert: true
 excerpt: 'Onward is a leading provider of quality, affordable homes for rent and sale in the North West. Once a collection of five individual organisations, they now own and manage over 35,000 homes across the region.'
+# metaTitle: '' # TODO: Review meta title - will use value of 'title' if not set
+# metaDescription: '' # TODO: Review meta description - will use value of 'excerpt' if not set
 ---
 
 Onward is a leading provider of quality, affordable homes for rent and sale in the North West. Once a collection of five individual organisations, they now own and manage over 35,000 homes across the region.

--- a/src/content/client-stories/streetstream/index.md
+++ b/src/content/client-stories/streetstream/index.md
@@ -10,6 +10,8 @@ navBackground: '#1D2C48'
 background: 'linear-gradient(0deg, #1D2C48 0%, #1D2C48 100%)'
 invert: true
 excerpt: 'Street Stream founder and CEO, James Middleton, approached Komodo in early 2014 with his idea for an app and customer website to help people sending their items securely from A-to-B.'
+# metaTitle: '' # TODO: Review meta title - will use value of 'title' if not set
+# metaDescription: '' # TODO: Review meta description - will use value of 'excerpt' if not set
 ---
 
 Street Stream founder and CEO, James Middleton, approached Komodo in early 2014 with his idea for an app and customer website to help people sending their items securely from A-to-B. 

--- a/src/content/client-stories/theo/index.md
+++ b/src/content/client-stories/theo/index.md
@@ -10,6 +10,8 @@ navBackground: '#003E52'
 background: 'linear-gradient(0deg, #003E52 0%, #003E52 100%)'
 invert: true
 excerpt: 'Theo is a small and compact device, with built-in 4G that fits seamlessly to any vehicle’s windscreen. With a high-quality dash cam, sensors and reactive intelligent voice, Theo ensures all eyes are on the road...'
+# metaTitle: '' # TODO: Review meta title - will use value of 'title' if not set
+# metaDescription: '' # TODO: Review meta description - will use value of 'excerpt' if not set
 ---
 
 Theo is a small and compact device, with built-in 4G that fits seamlessly to any vehicle’s windscreen. With a high-quality dash cam, sensors and reactive intelligent voice, Theo ensures all eyes are on the road - giving drivers total peace of mind.

--- a/src/content/contact/index.md
+++ b/src/content/contact/index.md
@@ -1,0 +1,6 @@
+---
+title: 'Contact Us'
+date: '2018-09-22'
+metaTitle: 'Contact Us' # TODO: Review meta title
+metaDescription: '' # TODO: Review meta description
+---

--- a/src/content/index/index.md
+++ b/src/content/index/index.md
@@ -3,4 +3,6 @@ title: 'We Help Teams Build Exceptional Digital Products That People Want to Use
 subtitle: 'DIGITAL PRODUCT CONSULTANCY'
 date: '2018-09-22'
 csimage: '../images/home-img@3x.png'
+metaTitle: 'Komodo' # TODO: Review page title
+# metaDescription: '' TODO: Review page description
 ---

--- a/src/content/insights/index.md
+++ b/src/content/insights/index.md
@@ -1,6 +1,8 @@
 ---
 title: 'Insights'
 date: '2018-09-22'
+metaTitle: 'Insights' # TODO: Review meta title
+# metaDescription: '' # TODO: Review meta description
 ---
 
 Curiosity is what drives us to learn and grow professionally enabling us to remain vigilant to change and the opportunities it presents for our clients. We document some of this learning and share it via our 'Insights' section.

--- a/src/content/services/index.md
+++ b/src/content/services/index.md
@@ -3,6 +3,8 @@ title: 'A Proposition to Help Your Team Deliver Exceptional Results'
 subtitle: 'We Have Your Back'
 date: '2018-09-22'
 csimage: '../images/services/service-img@3x.png'
+metaTitle: 'Services' # TODO: Review meta title
+# metaDescription: '' # TODO: Review meta description
 ---
 
 Demanding product roadmaps, complex user needs, data integration challenges, multiple platforms and fast-moving market environments are just a few issues that make it tough for even the best digital product and service teams to achieve the best results.

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -6,6 +6,10 @@ import FourOhFour from '../templates/404';
 export default (props) => {
   const hocProps = {
     htmlAst: props.data.allMarkdownRemark.edges[0].node.htmlAst,
+    pageMeta: {
+      title: 'Page not found',
+      description: '',
+    },
     ...props,
   };
 

--- a/src/pages/_blog.tsx
+++ b/src/pages/_blog.tsx
@@ -12,9 +12,9 @@ import Blog from '../templates/blog';
 import { findNode } from '../utils/nodes';
 
 export default (props) => {
-  const source_url = props.data.allWordpressPost.edges[0].node.featured_media
-    ? props.data.allWordpressPost.edges[0].node.featured_media.source_url
-    : null;
+  const post = props.data.allWordpressPost.edges[0].node;
+
+  const source_url = post.featured_media ? post.featured_media.source_url : null;
   let imageSource = '';
 
   if (source_url) {
@@ -32,13 +32,18 @@ export default (props) => {
     };
   });
 
-  const html = CleanSourceURL(props.data.allWordpressPost.edges[0].node.content);
+  const html = CleanSourceURL(post.content);
 
   const hocProps = {
     html,
     imageSource,
     insights,
     insightsIntro: (insightsIntro) ? insightsIntro.htmlAst : '',
+    title: post.title,
+    pageMeta: {
+      title: post.yoast.title || post.title,
+      description: post.yoast.metadesc || '',
+    },
     ...props,
   };
 
@@ -58,6 +63,10 @@ export const blogQuery = graphql`
           content
           featured_media {
             source_url
+          }
+          yoast {
+            title
+            metadesc
           }
         }
       }

--- a/src/pages/_client-story.tsx
+++ b/src/pages/_client-story.tsx
@@ -9,6 +9,7 @@ import { graphql } from 'gatsby';
 import CaseStudy from '../templates/client-story';
 import { siteMeta, komodoLogo, clientLogos, icons, avatars } from '../utils/site-queries';
 import { findNodes, findNode, findNodeRaw } from '../utils/nodes';
+import { pageMetaFromFrontmatter } from '../utils/page-meta';
 
 export default (props) => {
   const rootNode = findNode(`${props.pageContext.slug}/index`, props);
@@ -46,6 +47,7 @@ export default (props) => {
     caseStudiesIntro: caseStudiesIntro ? caseStudiesIntro.htmlAst : '',
     caseStudiesTitle: caseStudiesIntro ? caseStudiesIntro.frontmatter.title : '',
     contactsIntro: contactsIntro ? contactsIntro.htmlAst : '',
+    pageMeta: pageMetaFromFrontmatter(rootNode),
     ...props,
   };
 
@@ -82,6 +84,7 @@ export const caseStudyQuery = graphql`
             navBackground
             background
             invert
+            ...pageMeta
           }
           fileAbsolutePath
         }

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -3,6 +3,7 @@ import { graphql } from 'gatsby';
 import About from '../templates/about';
 import { siteMeta, komodoLogo, clientLogos, icons, avatars } from '../utils/site-queries';
 import { findNodes, findNode } from '../utils/nodes';
+import { pageMetaFromFrontmatter } from '../utils/page-meta';
 
 export default (props) => {
   const rootNode = findNode('about/index', props);
@@ -23,6 +24,7 @@ export default (props) => {
     purpose: (purpose) ? purpose.htmlAst : '',
     purposeIntro: (purpose) ? purpose.frontmatter.title : '',
     contactsIntro: (contactsIntro) ? contactsIntro.htmlAst : '',
+    pageMeta: pageMetaFromFrontmatter(rootNode),
     ...props,
   };
 
@@ -40,6 +42,7 @@ export const aboutQuery = graphql`
             title
             subtitle
             group
+            ...pageMeta
             csimage {
               childImageSharp {
                 fluidFull: fluid(maxWidth: 1170, quality: 100) {

--- a/src/pages/client-stories.tsx
+++ b/src/pages/client-stories.tsx
@@ -3,6 +3,7 @@ import { graphql } from 'gatsby';
 import CaseStudies from '../templates/client-stories';
 import { siteMeta, komodoLogo, clientLogos, icons, avatars } from '../utils/site-queries';
 import { findNodes, findNode } from '../utils/nodes';
+import { pageMetaFromFrontmatter } from '../utils/page-meta';
 
 export default (props) => {
   const caseStudies = findNodes('group', props, 'client-stories');
@@ -13,6 +14,7 @@ export default (props) => {
     caseStudies,
     contactsIntro: (contactsIntro) ? contactsIntro.htmlAst : '',
     caseStudiesIntro: (caseStudiesIntro) ? caseStudiesIntro.htmlAst : '',
+    pageMeta: pageMetaFromFrontmatter(caseStudiesIntro),
     ...props,
   };
 
@@ -38,6 +40,7 @@ export const caseStudiesQuery = graphql`
               }
             }
             group
+            ...pageMeta
           }
           fileAbsolutePath
         }

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -3,14 +3,17 @@ import { graphql } from 'gatsby';
 import Contact from '../templates/contact';
 import { siteMeta, komodoLogo, clientLogos, icons, avatars } from '../utils/site-queries';
 import { findNodes, findNode } from '../utils/nodes';
+import { pageMetaFromFrontmatter } from '../utils/page-meta';
 
 export default (props) => {
+  const rootNode = findNode('contact/index', props);
   const contactsIntro = findNode('contacts/index', props);
   const career = findNode('contacts/career', props);
 
   const hocProps = {
     contactsIntro: (contactsIntro) ? contactsIntro.htmlAst : '',
     career: (career) ? career.htmlAst : '',
+    pageMeta: pageMetaFromFrontmatter(rootNode),
     ...props,
   };
 
@@ -28,6 +31,7 @@ export const contactQuery = graphql`
             title
             subtitle
             group
+            ...pageMeta
           }
           fileAbsolutePath
         }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,6 +4,7 @@ import Index from '../templates/index';
 import Placeholder from '../assets/images/placeholder.png';
 import { findNodes, findNode, findNodeRaw } from '../utils/nodes';
 import CleanSourceURL from '../utils/clean-source-url';
+import { pageMetaFromFrontmatter } from '../utils/page-meta';
 
 export default (props) => {
   const rootNode = findNode('index/index', props);
@@ -44,6 +45,7 @@ export default (props) => {
     insightsIntro: (insightsIntro) ? insightsIntro.htmlAst : '',
     contactsIntro: (contactsIntro) ? contactsIntro.htmlAst : '',
     testimonial: (testimonial) ? testimonial.frontmatter : '',
+    pageMeta: pageMetaFromFrontmatter(rootNode),
     ...props,
   };
 
@@ -85,6 +87,7 @@ export const pageQuery = graphql`
               }
             }
             group
+            ...pageMeta
           }
           fileAbsolutePath
         }

--- a/src/pages/insights.tsx
+++ b/src/pages/insights.tsx
@@ -4,6 +4,7 @@ import Insights from '../templates/insights';
 import Placeholder from '../assets/images/placeholder.png';
 import CleanSourceURL from '../utils/clean-source-url';
 import { findNode } from '../utils/nodes';
+import { pageMetaFromFrontmatter } from '../utils/page-meta';
 
 export default (props) => {
   const posts = props.data.allWordpressPost.edges.map((edge) => {
@@ -20,6 +21,7 @@ export default (props) => {
 
   const hocProps = {
     insightsIntro: (insightsIntro) ? insightsIntro.htmlAst : '',
+    pageMeta: pageMetaFromFrontmatter(insightsIntro),
     ...props,
   };
 
@@ -44,6 +46,7 @@ export const blogListQuery = graphql`
                 }
               }
             }
+            ...pageMeta
           }
           fileAbsolutePath
         }

--- a/src/pages/services.tsx
+++ b/src/pages/services.tsx
@@ -3,6 +3,7 @@ import { graphql } from 'gatsby';
 import Services from '../templates/services';
 import { siteMeta, komodoLogo, clientLogos, icons, avatars } from '../utils/site-queries';
 import { findNodes, findNode } from '../utils/nodes';
+import { pageMetaFromFrontmatter } from '../utils/page-meta';
 
 export default (props) => {
   const rootNode = findNode('services/index', props);
@@ -22,6 +23,7 @@ export default (props) => {
     servicesIntro: (servicesIntro) ? servicesIntro.htmlAst : '',
     standardsIntro: (standardsIntro) ? standardsIntro.htmlAst : '',
     contactsIntro: (contactsIntro) ? contactsIntro.htmlAst : '',
+    pageMeta: pageMetaFromFrontmatter(rootNode),
     ...props,
   };
 
@@ -39,6 +41,7 @@ export const servicesQuery = graphql`
             title
             subtitle
             group
+            ...pageMeta
             csimage {
               childImageSharp {
                 fluidFull: fluid(maxWidth: 1170, quality: 100) {

--- a/src/templates/404.tsx
+++ b/src/templates/404.tsx
@@ -8,7 +8,7 @@ const renderAst = new rehypeReact({
 }).Compiler;
 
 export default (props) => (
-  <Layout data={props.data} inverted={true} background="#EAEAEA">
+  <Layout data={props.data} pageMeta={props.pageMeta} inverted={true} background="#EAEAEA">
     <TitleText
       title="Four oh Four"
       subtitle="Page Not Found"

--- a/src/templates/about.tsx
+++ b/src/templates/about.tsx
@@ -5,6 +5,7 @@ import TwoColumn from '../components/twocolumn';
 import ContactSection from '../components/contactsection';
 import TitleText from '../components/titletext';
 import VCard from '../components/vcard';
+import { PageMeta } from '../components/seo/types';
 
 const renderAst = new rehypeReact({
   createElement: React.createElement,
@@ -29,11 +30,12 @@ interface AboutPageProps {
   standardsIntro: any;
   contactsIntro: any;
   data?: any;
+  pageMeta?: PageMeta;
 }
 
 export default (props: AboutPageProps) => {
   return (
-    <Layout data={props.data}>
+    <Layout data={props.data} pageMeta={props.pageMeta}>
       <TitleText
         subtitle={props.subtitle}
         title={props.title}

--- a/src/templates/blog.tsx
+++ b/src/templates/blog.tsx
@@ -12,10 +12,10 @@ export default (props) => {
     createElement: React.createElement,
   }).Compiler;
 
-  const title = props.data.allWordpressPost ? props.data.allWordpressPost.edges[0].node.title : "No Title Found";
-  return <Layout data={props.data}>
+  return (
+    <Layout data={props.data} pageMeta={props.pageMeta}>
       <TitleText
-        title={title}
+        title={props.title}
         subtitle={`Insights`}
         background={'#000000'}
         invert={true}

--- a/src/templates/blog.tsx
+++ b/src/templates/blog.tsx
@@ -25,24 +25,24 @@ export default (props) => {
         showShowreel={false}
         centered={true}
       />
-
       <CenterContent className={`topPaddingExtraLarge bottomPaddingNone`}>
         <div dangerouslySetInnerHTML={{ __html: props.html }} />
       </CenterContent>
       <ContentSection title="Insights" className="topPaddingSmall">
-          {renderAst(props.insightsIntro)}
+        {renderAst(props.insightsIntro)}
       </ContentSection>
       <BlogGrid>
-          {props.insights.map((insight) => {
-            return (
-              <BlogPost
-                  key={insight.node.title}
-                  slug={insight.node.slug}
-                  title={insight.node.title}
-                  image={insight.node.imageSource}
-              />
-            );
-          })}
+        {props.insights.map((insight) => {
+          return (
+            <BlogPost
+              key={insight.node.title}
+              slug={insight.node.slug}
+              title={insight.node.title}
+              image={insight.node.imageSource}
+            />
+          );
+        })}
       </BlogGrid>
-    </Layout>;
+    </Layout>
+  );
 };

--- a/src/templates/client-stories.tsx
+++ b/src/templates/client-stories.tsx
@@ -14,7 +14,7 @@ const renderAst = new rehypeReact({
 
 export default (props) => {
   return (
-    <Layout data={props.data} inverted={true} background="#EAEAEA">
+    <Layout data={props.data} pageMeta={props.pageMeta} inverted={true} background="#EAEAEA">
       <TitleText
         title="Client Stories"
         subtitle="What We Do"

--- a/src/templates/client-story.tsx
+++ b/src/templates/client-story.tsx
@@ -17,7 +17,7 @@ const renderAst = new rehypeReact({
 
 export default (props) => {
   return (
-    <Layout data={props.data} background={props.navBackground}>
+    <Layout data={props.data} pageMeta={props.pageMeta} background={props.navBackground}>
       <TitleText
         subtitle={props.subtitle}
         title={props.title}

--- a/src/templates/contact.tsx
+++ b/src/templates/contact.tsx
@@ -6,6 +6,7 @@ import ContactJobs from '../components/contactjobs';
 import VCard from '../components/vcard';
 import ContactSection from '../components/contactsection';
 import Img from 'gatsby-image';
+import { PageMeta } from '../components/seo/types';
 
 const renderAst = new rehypeReact({
   createElement: React.createElement,
@@ -20,11 +21,12 @@ interface ContactPageProps {
   contactsIntro: any;
   career: any;
   data?: any;
+  pageMeta?: PageMeta;
 }
 
 export default (props: ContactPageProps) => {
   return (
-    <Layout data={props.data} inverted={true} background="#EAEAEA">
+    <Layout data={props.data} pageMeta={props.pageMeta} inverted={true} background="#EAEAEA">
       <ContactSection className="topPaddingLarge">
         {renderAst(props.contactsIntro)}
         <VCard person="Armin" avatars={props.data} />

--- a/src/templates/index.tsx
+++ b/src/templates/index.tsx
@@ -14,6 +14,7 @@ import TitleText from '../components/titletext';
 import TripleSection from '../components/triplesection';
 import TripleFeature from '../components/triplefeature';
 import Testimonial from '../components/testimonial';
+import { PageMeta } from '../components/seo/types';
 
 const renderAst = new rehypeReact({
   createElement: React.createElement,
@@ -58,11 +59,12 @@ interface IndexPageProps {
   contactsIntro: any;
   data?: any;
   testimonial: any;
+  pageMeta: PageMeta;
 }
 
 export default (props: IndexPageProps) => {
   return (
-    <Layout data={props.data}>
+    <Layout data={props.data} pageMeta={props.pageMeta}>
       <TitleText
         title={props.title}
         subtitle={props.subtitle}

--- a/src/templates/insights.tsx
+++ b/src/templates/insights.tsx
@@ -31,7 +31,7 @@ export default (props) => {
   };
 
   return (
-    <Layout data={props.data} inverted={true} background="#EAEAEA">
+    <Layout data={props.data} pageMeta={props.pageMeta} inverted={true} background="#EAEAEA">
       <TitleText
         title="Insights"
         subtitle="What We Know"

--- a/src/templates/services.tsx
+++ b/src/templates/services.tsx
@@ -10,6 +10,7 @@ import VCard from '../components/vcard';
 import TitleText from '../components/titletext';
 import TripleSection from '../components/triplesection';
 import TripleFeature from '../components/triplefeature';
+import { PageMeta } from '../components/seo/types';
 
 const renderAst = new rehypeReact({
   createElement: React.createElement,
@@ -34,11 +35,12 @@ interface ServicePageProps {
   standardsIntro: any;
   contactsIntro: any;
   data?: any;
+  pageMeta?: PageMeta;
 }
 
 export default (props: ServicePageProps) => {
   return (
-    <Layout data={props.data}>
+    <Layout data={props.data} pageMeta={props.pageMeta}>
       <TitleText
         title={props.title}
         subtitle={props.subtitle}

--- a/src/utils/nodes.tsx
+++ b/src/utils/nodes.tsx
@@ -4,7 +4,7 @@
  */
 import { fileToSlug } from './file-to-slug';
 
-interface Edge {
+export interface Edge {
   node: {
     frontmatter: any;
     fileAbsolutePath: string;

--- a/src/utils/page-meta.tsx
+++ b/src/utils/page-meta.tsx
@@ -1,0 +1,16 @@
+import { PageMeta } from '../components/seo/types';
+import { Edge } from './nodes';
+
+export const pageMetaFromFrontmatter = (page: Edge | null): PageMeta => {
+  if (!page) {
+    return { title: '', description: '' };
+  }
+
+  const title = page.metaTitle || page.title || '';
+  const description = page.metaDescription || page.excerpt || '';
+
+  return {
+    title,
+    description,
+  };
+};

--- a/src/utils/site-queries.js
+++ b/src/utils/site-queries.js
@@ -12,6 +12,13 @@ export const siteMeta = graphql`
   }
 `;
 
+export const pageMeta = graphql`
+  fragment pageMeta on MarkdownRemarkFrontmatter {
+    metaTitle
+    metaDescription
+  }
+`;
+
 export const komodoLogo = graphql`
   fragment komodoLogo on Query {
     logo: file(relativePath: { eq: "images/Komodo@3x.png" }) {


### PR DESCRIPTION
See JIRA tickets **KOM-16** and **KOM-17** for more information and discussion of outstanding work before merging.

- Update the SEO component to utilise title and description values.
- Modify page components and layouts to pass the values through

**Static Pages:**
Adds support for specifying a page's title and meta description in the frontmatter.

**Insights:**
Attempts to extract the title and description from the YoastSEO portion of the WordPress API response