### PR TITLE
WIP: Fix duplicate content issues

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -15,6 +15,7 @@ interface Props {
   background?: string;
   inverted?: boolean;
   noindex?: boolean;
+  canonical?: string;
 }
 
 const Layout: React.SFC<Props> = ({
@@ -23,7 +24,8 @@ const Layout: React.SFC<Props> = ({
   children,
   background = '',
   inverted = false,
-  noindex = false
+  noindex = false,
+  canonical = '/'
 }) => {
   const logo = !inverted ? data.logo.childImageSharp : data.logo_inverted.childImageSharp;
 
@@ -37,6 +39,7 @@ const Layout: React.SFC<Props> = ({
         siteName={data.site.siteMetadata.name}
         description={description}
         noindex={noindex}
+        canonical={canonical}
         // TODO: fix
         url="http://test"
         title={title}

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -14,6 +14,7 @@ interface Props {
   pageMeta?: PageMeta;
   background?: string;
   inverted?: boolean;
+  noindex?: boolean;
 }
 
 const Layout: React.SFC<Props> = ({
@@ -22,6 +23,7 @@ const Layout: React.SFC<Props> = ({
   children,
   background = '',
   inverted = false,
+  noindex = false
 }) => {
   const logo = !inverted ? data.logo.childImageSharp : data.logo_inverted.childImageSharp;
 
@@ -34,6 +36,7 @@ const Layout: React.SFC<Props> = ({
         defaultTitle={data.site.siteMetadata.title}
         siteName={data.site.siteMetadata.name}
         description={description}
+        noindex={noindex}
         // TODO: fix
         url="http://test"
         title={title}

--- a/src/components/seo/index.tsx
+++ b/src/components/seo/index.tsx
@@ -16,6 +16,7 @@ interface Props {
   url: string;
   children?: ReactNode;
   siteName: string;
+  noindex?: boolean;
 }
 
 const SEO: React.SFC<Props> = ({
@@ -27,6 +28,7 @@ const SEO: React.SFC<Props> = ({
   url,
   children,
   siteName,
+  noindex = false
 }) => {
   return (
     <>
@@ -35,6 +37,7 @@ const SEO: React.SFC<Props> = ({
         defaultTitle={defaultTitle}
         description={description}
         separator={separator}
+        noindex={noindex}
         key="seo.meta"
       >
         {children}

--- a/src/components/seo/index.tsx
+++ b/src/components/seo/index.tsx
@@ -17,6 +17,7 @@ interface Props {
   children?: ReactNode;
   siteName: string;
   noindex?: boolean;
+  canonical?: string;
 }
 
 const SEO: React.SFC<Props> = ({
@@ -28,7 +29,8 @@ const SEO: React.SFC<Props> = ({
   url,
   children,
   siteName,
-  noindex = false
+  noindex = false,
+  canonical = '/'
 }) => {
   return (
     <>
@@ -38,6 +40,7 @@ const SEO: React.SFC<Props> = ({
         description={description}
         separator={separator}
         noindex={noindex}
+        canonical={canonical}
         key="seo.meta"
       >
         {children}

--- a/src/components/seo/meta.tsx
+++ b/src/components/seo/meta.tsx
@@ -6,6 +6,7 @@ interface Props {
   defaultTitle: string;
   description: string;
   separator?: string;
+  noindex?: boolean;
   children?: ReactNode;
 }
 
@@ -14,6 +15,7 @@ const Meta: React.SFC<Props> = ({
   title,
   description,
   separator = ' - ',
+  noindex = false,
   children,
 }) => {
   return (
@@ -23,6 +25,7 @@ const Meta: React.SFC<Props> = ({
     >
       {title && <title>{title}</title>}
       <meta name="description" content={description} />
+      {noindex && <meta name="robots" content="noindex, follow" />}
       {children}
     </Helmet>
   );

--- a/src/components/seo/meta.tsx
+++ b/src/components/seo/meta.tsx
@@ -7,6 +7,7 @@ interface Props {
   description: string;
   separator?: string;
   noindex?: boolean;
+  canonical?: string;
   children?: ReactNode;
 }
 
@@ -16,6 +17,7 @@ const Meta: React.SFC<Props> = ({
   description,
   separator = ' - ',
   noindex = false,
+  canonical = '/',
   children,
 }) => {
   return (
@@ -25,6 +27,7 @@ const Meta: React.SFC<Props> = ({
     >
       {title && <title>{title}</title>}
       <meta name="description" content={description} />
+      {canonical && <link rel="canonical" href={canonical} />}
       {noindex && <meta name="robots" content="noindex, follow" />}
       {children}
     </Helmet>

--- a/src/templates/about.tsx
+++ b/src/templates/about.tsx
@@ -34,6 +34,7 @@ interface AboutPageProps {
 }
 
 export default (props: AboutPageProps) => {
+  console.log(props.pageResources.page.path);
   return (
     <Layout data={props.data} pageMeta={props.pageMeta}>
       <TitleText

--- a/src/templates/blog.tsx
+++ b/src/templates/blog.tsx
@@ -13,6 +13,7 @@ export default (props) => {
     createElement: React.createElement,
   }).Compiler;
 
+  console.log(props.pageResources.page.path);
   return (
     <Layout data={props.data} pageMeta={props.pageMeta}>
       <TitleText

--- a/src/templates/client-stories.tsx
+++ b/src/templates/client-stories.tsx
@@ -13,6 +13,7 @@ const renderAst = new rehypeReact({
 }).Compiler;
 
 export default (props) => {
+  console.log(props.pageResources.page.path);
   return (
     <Layout data={props.data} pageMeta={props.pageMeta} inverted={true} background="#EAEAEA">
       <TitleText

--- a/src/templates/client-story.tsx
+++ b/src/templates/client-story.tsx
@@ -16,6 +16,7 @@ const renderAst = new rehypeReact({
 }).Compiler;
 
 export default (props) => {
+  console.log(props.pageResources.page.path);
   return (
     <Layout data={props.data} pageMeta={props.pageMeta} background={props.navBackground}>
       <TitleText

--- a/src/templates/contact.tsx
+++ b/src/templates/contact.tsx
@@ -25,6 +25,7 @@ interface ContactPageProps {
 }
 
 export default (props: ContactPageProps) => {
+  console.log(props.pageResources.page.path);
   return (
     <Layout data={props.data} pageMeta={props.pageMeta} inverted={true} background="#EAEAEA">
       <ContactSection className="topPaddingLarge">

--- a/src/templates/index.tsx
+++ b/src/templates/index.tsx
@@ -64,6 +64,7 @@ interface IndexPageProps {
 }
 
 export default (props: IndexPageProps) => {
+  console.log(props.pageResources.page.path);
   return (
     <Layout data={props.data} pageMeta={props.pageMeta}>
       <TitleText

--- a/src/templates/insights.tsx
+++ b/src/templates/insights.tsx
@@ -30,6 +30,7 @@ export default (props) => {
     },
   };
 
+  console.log(props.pageResources.page.path);
   return (
     <Layout data={props.data} pageMeta={props.pageMeta} noindex={true} inverted={true} background="#EAEAEA">
       <TitleText

--- a/src/templates/insights.tsx
+++ b/src/templates/insights.tsx
@@ -31,7 +31,7 @@ export default (props) => {
   };
 
   return (
-    <Layout data={props.data} pageMeta={props.pageMeta} inverted={true} background="#EAEAEA">
+    <Layout data={props.data} pageMeta={props.pageMeta} noindex={true} inverted={true} background="#EAEAEA">
       <TitleText
         title="Insights"
         subtitle="What We Know"

--- a/src/templates/services.tsx
+++ b/src/templates/services.tsx
@@ -39,6 +39,7 @@ interface ServicePageProps {
 }
 
 export default (props: ServicePageProps) => {
+  console.log(props.pageResources.page.path);
   return (
     <Layout data={props.data} pageMeta={props.pageMeta}>
       <TitleText


### PR DESCRIPTION
Implement canonical URLs and of 301 redirects for the “no trailing slash versions of pages”.

Set Insights blog  page archives to “no index” as below:

<meta name="robots" content="noindex, follow">
