### PR TITLE
Fix duplicate content issues

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -5,16 +5,16 @@ module.exports = {
     description: 'Home of Komodo Digital',
   },
   plugins: [
-    { 
-      resolve: 'gatsby-plugin-typescript', 
-      options: { 
-        transpileOnly: true, // default 
-        compilerOptions: { 
-          target: 'esnext', 
-          experimentalDecorators: true, 
-          jsx: 'react', 
-        }, 
-      } 
+    {
+      resolve: 'gatsby-plugin-typescript',
+      options: {
+        transpileOnly: true, // default
+        compilerOptions: {
+          target: 'esnext',
+          experimentalDecorators: true,
+          jsx: 'react',
+        },
+      },
     },
     {
       resolve: `gatsby-source-filesystem`,
@@ -24,7 +24,15 @@ module.exports = {
       },
     },
     `gatsby-plugin-react-helmet`,
+    {
+      resolve: `gatsby-plugin-react-helmet-canonical-urls`,
+      options: {
+        siteUrl: `https://www.komododigital.co.uk`,
+        noTrailingSlash: true,
+      },
+    },
     `gatsby-plugin-offline`,
+    `gatsby-plugin-remove-trailing-slashes`,
     `gatsby-transformer-sharp`,
     `gatsby-plugin-sharp`,
     `gatsby-plugin-postcss`,
@@ -58,9 +66,9 @@ module.exports = {
       resolve: 'gatsby-source-wordpress',
       options: {
         /*
-       * The base URL of the Wordpress site without the trailingslash and the protocol. This is required.
-       * Example : 'gatsbyjsexamplewordpress.wordpress.com' or 'www.example-site.com'
-       */
+         * The base URL of the Wordpress site without the trailingslash and the protocol. This is required.
+         * Example : 'gatsbyjsexamplewordpress.wordpress.com' or 'www.example-site.com'
+         */
         baseUrl: 'blog.komododigital.co.uk',
         // The protocol. This can be http or https.
         protocol: 'https',
@@ -127,13 +135,13 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-sentry',
       options: {
-        dsn: 'https://314dbec933e44245ae35b28fcb15bc96@sentry.io/1289118'
+        dsn: 'https://314dbec933e44245ae35b28fcb15bc96@sentry.io/1289118',
       },
     },
     {
       resolve: `gatsby-plugin-google-analytics`,
       options: {
-        trackingId: "UA-1236119-5",
+        trackingId: 'UA-1236119-5',
         // Puts tracking script in the head instead of the body
         head: false,
         // Setting this parameter is optional
@@ -149,6 +157,6 @@ module.exports = {
         // siteSpeedSampleRate: 10,
         // cookieDomain: "example.com",
       },
-    }
+    },
   ],
 };

--- a/package.json
+++ b/package.json
@@ -81,6 +81,8 @@
     "gatsby-plugin-offline": "^2.0.17",
     "gatsby-plugin-postcss": "^2.0.1",
     "gatsby-plugin-react-helmet": "^3.0.2",
+    "gatsby-plugin-react-helmet-canonical-urls": "^1.2.0",
+    "gatsby-plugin-remove-trailing-slashes": "^2.1.2",
     "gatsby-plugin-sentry": "^1.0.1",
     "gatsby-plugin-sharp": "^2.0.13",
     "gatsby-plugin-typescript": "2.0.12",

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -14,6 +14,7 @@ interface Props {
   pageMeta?: PageMeta;
   background?: string;
   inverted?: boolean;
+  noindex?: boolean;
 }
 
 const Layout: React.SFC<Props> = ({
@@ -22,6 +23,7 @@ const Layout: React.SFC<Props> = ({
   children,
   background = '',
   inverted = false,
+  noindex = false
 }) => {
   const logo = !inverted ? data.logo.childImageSharp : data.logo_inverted.childImageSharp;
 
@@ -34,6 +36,7 @@ const Layout: React.SFC<Props> = ({
         defaultTitle={data.site.siteMetadata.title}
         siteName={data.site.siteMetadata.name}
         description={description}
+        noindex={noindex}
         // TODO: fix
         url="http://test"
         title={title}

--- a/src/components/seo/index.tsx
+++ b/src/components/seo/index.tsx
@@ -16,6 +16,7 @@ interface Props {
   url: string;
   children?: ReactNode;
   siteName: string;
+  noindex?: boolean;
 }
 
 const SEO: React.SFC<Props> = ({
@@ -27,6 +28,7 @@ const SEO: React.SFC<Props> = ({
   url,
   children,
   siteName,
+  noindex = false
 }) => {
   return (
     <>
@@ -35,6 +37,7 @@ const SEO: React.SFC<Props> = ({
         defaultTitle={defaultTitle}
         description={description}
         separator={separator}
+        noindex={noindex}
         key="seo.meta"
       >
         {children}

--- a/src/components/seo/meta.tsx
+++ b/src/components/seo/meta.tsx
@@ -6,6 +6,7 @@ interface Props {
   defaultTitle: string;
   description: string;
   separator?: string;
+  noindex?: boolean;
   children?: ReactNode;
 }
 
@@ -14,6 +15,7 @@ const Meta: React.SFC<Props> = ({
   title,
   description,
   separator = ' - ',
+  noindex = false,
   children,
 }) => {
   return (
@@ -23,6 +25,7 @@ const Meta: React.SFC<Props> = ({
     >
       {title && <title>{title}</title>}
       <meta name="description" content={description} />
+      {noindex && <meta name="robots" content="noindex, follow" />}
       {children}
     </Helmet>
   );

--- a/src/templates/blog.tsx
+++ b/src/templates/blog.tsx
@@ -14,7 +14,7 @@ export default (props) => {
   }).Compiler;
 
   return (
-    <Layout data={props.data} pageMeta={props.pageMeta}>
+    <Layout data={props.data} pageMeta={props.pageMeta} noindex={true}>
       <TitleText
         title={props.title}
         subtitle={`Insights`}

--- a/src/templates/insights.tsx
+++ b/src/templates/insights.tsx
@@ -31,7 +31,7 @@ export default (props) => {
   };
 
   return (
-    <Layout data={props.data} pageMeta={props.pageMeta} noindex={true} inverted={true} background="#EAEAEA">
+    <Layout data={props.data} pageMeta={props.pageMeta} inverted={true} background="#EAEAEA">
       <TitleText
         title="Insights"
         subtitle="What We Know"

--- a/src/templates/insights.tsx
+++ b/src/templates/insights.tsx
@@ -31,7 +31,7 @@ export default (props) => {
   };
 
   return (
-    <Layout data={props.data} pageMeta={props.pageMeta} inverted={true} background="#EAEAEA">
+    <Layout data={props.data} pageMeta={props.pageMeta} noindex={true} inverted={true} background="#EAEAEA">
       <TitleText
         title="Insights"
         subtitle="What We Know"

--- a/yarn.lock
+++ b/yarn.lock
@@ -938,6 +938,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.3.1":
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.4.tgz#cb7d1ad7c6d65676e66b47186577930465b5271b"
+  integrity sha512-Na84uwyImZZc3FKf4aUF1tysApzwf3p2yuFBIyBfbzT5glzKTdvYI4KVW4kcgjrzoGUjC7w3YyCHcJKaRxsr2Q==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.0.0", "@babel/template@^7.1.0", "@babel/template@^7.2.2", "@babel/template@^7.4.0":
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.0.tgz#12474e9c077bae585c5d835a95c0b0b790c25c8b"
@@ -7083,10 +7090,24 @@ gatsby-plugin-postcss@^2.0.1:
     "@babel/runtime" "^7.0.0"
     postcss-loader "^3.0.0"
 
+gatsby-plugin-react-helmet-canonical-urls@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-react-helmet-canonical-urls/-/gatsby-plugin-react-helmet-canonical-urls-1.2.0.tgz#d054220c3cfecb257b82d2fff3a8688dbd81d0c3"
+  integrity sha512-nulC+BWEZQfyd8jhcb6ECE/BNArY2U+SOy1DmcwhMHs7rgWLTd8t9fXw/B9JCUQQrF9yXyqupj34sQSeQfsyBQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+
 gatsby-plugin-react-helmet@^3.0.2:
   version "3.0.12"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-3.0.12.tgz#805252b54ea4044d286d2158991429aa4f60aa02"
   integrity sha512-x1DXKceTuEDePN9HcQymzQ+oBgmT3PKVQLSFbxrOECiC71cQRp03FJK0i/ClAkMJ3IJNLCGJDvi7dKydkc6dvw==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
+gatsby-plugin-remove-trailing-slashes@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-remove-trailing-slashes/-/gatsby-plugin-remove-trailing-slashes-2.1.2.tgz#f6622338b661b291804ec4a20409da1e54b85876"
+  integrity sha512-CSAsXXcfQ3gDOfs+5P/9DdC8ErFA40Z7saxzJSk56fu2tzrmvrhcKCpXptPZTdY7h7clDwZUN6xiJ2vZlpuhyA==
   dependencies:
     "@babel/runtime" "^7.0.0"
 


### PR DESCRIPTION
Implement canonical URLs and of 301 redirects for the “no trailing slash versions of pages”.

Set Insights blog  page archives to “no index” as below:

<meta name="robots" content="noindex, follow">

1) I believe 301 redirect should be done in backend config?