### PR TITLE
Wrap link round client story div rather than grid wrapper

### DIFF
--- a/src/components/casestudy/casestudy.css
+++ b/src/components/casestudy/casestudy.css
@@ -3,6 +3,7 @@
 .case-study-link-element {
     text-decoration: none;
     color: #000;
+    grid-column: 2 / 16;
 }
 
 .case-study-link-wrapper {
@@ -12,7 +13,6 @@
 .case-study-link {
     background-color: #04114A;
     box-shadow: 0 1px 4px 0 rgba(0,0,0,0.2);
-    grid-column: 2 / 16;
     display: flex;
     flex-direction: column;
     transition: all 0.2s ease;
@@ -111,7 +111,7 @@ a:hover .case-study-link > div.content span.linktext {
 }
 
 @media (--desktop-viewport) {
-    .case-study-link {
+    .case-study-link-element {
         grid-column: 3 / 15;
     }
     .case-study-link > div.content {

--- a/src/components/casestudy/index.tsx
+++ b/src/components/casestudy/index.tsx
@@ -43,8 +43,8 @@ interface Props {
  */
 const CaseStudyLink: React.SFC<Props> = ({ image, subtitle, title, children, link = '#' }) => {
   return (
-    <Link to={link} className="case-study-link-element">
-      <div className="komodoGridWrapper case-study-link-wrapper">
+    <div className="komodoGridWrapper case-study-link-wrapper">
+      <Link to={link} className="case-study-link-element">
         <div className="case-study-link">
           <div
             className="img"
@@ -59,8 +59,8 @@ const CaseStudyLink: React.SFC<Props> = ({ image, subtitle, title, children, lin
             <span className="linktext">Read Case Study</span>
           </div>
         </div>
-      </div>
-    </Link>
+      </Link>
+    </div>
   );
 };
 


### PR DESCRIPTION
**What this PR does**

* Fixes the issue https://trello.com/c/pg5zYNTf/43-whole-horizontal-width-is-clickable-on-client-stories-page
* Wraps the case study link with an anchor tag rather than the grid wrapper so that the entire width of the grid wrapper is not clickable, move grid column definitions to anchor tag rather than the case study link div