### PR TITLE
Feature/schema article markup

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -6,7 +6,7 @@ import LegalFooter from './legalfooter';
 import '../assets/css/cookies.css';
 import './layout.css';
 import Img from 'gatsby-image';
-import { PageMeta } from './seo/types';
+import { PageMeta, SchemaDataType } from './seo/types';
 
 interface Props {
   children?: ReactNode;
@@ -15,6 +15,7 @@ interface Props {
   background?: string;
   inverted?: boolean;
   noindex?: boolean;
+  schemaData?: SchemaDataType;
 }
 
 const Layout: React.SFC<Props> = ({
@@ -23,7 +24,8 @@ const Layout: React.SFC<Props> = ({
   children,
   background = '',
   inverted = false,
-  noindex = false
+  noindex = false,
+  schemaData,
 }) => {
   const logo = !inverted ? data.logo.childImageSharp : data.logo_inverted.childImageSharp;
 
@@ -37,6 +39,7 @@ const Layout: React.SFC<Props> = ({
         siteName={data.site.siteMetadata.name}
         description={description}
         noindex={noindex}
+        schemaData={schemaData}
         // TODO: fix
         url="http://test"
         title={title}

--- a/src/components/seo/index.tsx
+++ b/src/components/seo/index.tsx
@@ -2,6 +2,8 @@ import React, { ReactNode } from 'react';
 import Meta from './meta';
 import Twitter from './twitter';
 import Facebook from './facebook';
+import SchemaData from './schemaData';
+import { PageMeta, SchemaDataType } from './seo/types';
 
 interface Props {
   title?: string;
@@ -16,6 +18,7 @@ interface Props {
   children?: ReactNode;
   siteName: string;
   noindex?: boolean;
+  schemaData?: SchemaDataType;
 }
 
 const SEO: React.SFC<Props> = ({
@@ -26,7 +29,8 @@ const SEO: React.SFC<Props> = ({
   url,
   children,
   siteName,
-  noindex = false
+  noindex = false,
+  schemaData,
 }) => {
   return (
     <>
@@ -53,6 +57,7 @@ const SEO: React.SFC<Props> = ({
         url={url}
         key="seo.facebook"
       />
+      <SchemaData schemaData={schemaData} />
     </>
   );
 };

--- a/src/components/seo/schemaData.tsx
+++ b/src/components/seo/schemaData.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import Helmet from 'react-helmet';
+
+import { SchemaDataType } from './types';
+
+const getAuthor = (html: string): string => {
+  const parser = new DOMParser();
+  const htmldoc = parser.parseFromString(html, 'text/html');
+  const authorString = htmldoc.querySelector('h5');
+  if (authorString) {
+    const authorStringComponents = authorString.innerText.split('BY ');
+
+    if (authorStringComponents) {
+      return authorStringComponents[authorStringComponents.length - 1];
+    }
+  }
+  return '';
+};
+
+export const getSchemaData = (post: any): SchemaDataType => {
+  const date = new Date(post.date);
+  const formatted_date = date.getFullYear() + '-' + date.getMonth() + '-' + date.getDate();
+  const author = getAuthor(post.html);
+
+  return {
+    title: post.title,
+    date: formatted_date,
+    author,
+    imageURL: 'https://blog.komododigital.co.uk' + post.featured_media.source_url,
+    body: post.html,
+    url: window.location.href,
+  };
+};
+
+interface Props {
+  schemaData: SchemaDataType;
+}
+
+const SchemaData: React.SFC<Props> = ({ schemaData }) => {
+  if (!schemaData) {
+    return null;
+  }
+
+  const authorString = schemaData.author
+    ? `
+      "author" : {
+        "@type" : "Person",
+        "name" : "${schemaData.author}"
+      },`
+    : '';
+
+  const schemaDataString = `
+    {
+      "@context" : "http://schema.org",
+      "@type" : "Article",
+      "name" : "${schemaData.title}",${authorString}
+      "datePublished" : "${schemaData.title}",
+      "image" : "${schemaData.image}",
+      "articleBody" : "${schemaData.body}"
+      "url" : "${schemaData.url}",
+      "publisher" : {
+        "@type" : "Organization",
+        "name" : "Komodo Digital"
+      }
+    }
+  `;
+  return (
+    <Helmet>
+      <script type="application/ld+json">{schemaDataString}</script>
+    </Helmet>
+  );
+};
+
+export default SchemaData;

--- a/src/components/seo/schemaData.tsx
+++ b/src/components/seo/schemaData.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Helmet from 'react-helmet';
-import jsdom from 'jsdom';
 
 import { SchemaDataType } from './types';
 
@@ -33,6 +32,10 @@ export const getSchemaData = (post: any): SchemaDataType => {
     ? 'https://blog.komododigital.co.uk' + post.featured_media.source_url
     : null;
 
+  // This will only return false in nodeJS as all modern browsers have a window
+  const url =
+    typeof window === 'undefined' ? 'https://www.komododigital.co.uk' : window.location.href;
+
   return {
     title: post.title,
     headline: post.title,
@@ -40,7 +43,7 @@ export const getSchemaData = (post: any): SchemaDataType => {
     author,
     imageURL,
     body: cleanBody(post.html),
-    url: window.location.href,
+    url,
   };
 };
 
@@ -52,6 +55,10 @@ const SchemaData: React.SFC<Props> = ({ schemaData }) => {
   if (!schemaData) {
     return null;
   }
+
+  // This will only return false in nodeJS as all modern browsers have a window
+  const url =
+    typeof window === 'undefined' ? 'https://www.komododigital.co.uk' : window.location.href;
 
   // If no image just use the Komodo Logo
   const image = schemaData.imageURL
@@ -80,7 +87,7 @@ const SchemaData: React.SFC<Props> = ({ schemaData }) => {
       "@type" : "Article",
       "mainEntityOfPage": {
          "@type": "WebPage",
-         "@id": "${window.location.href}"
+         "@id": "${url}"
       },
       "name" : "${schemaData.title}",${authorString}
       "headline" : "${schemaData.title}",

--- a/src/components/seo/schemaData.tsx
+++ b/src/components/seo/schemaData.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
 import Helmet from 'react-helmet';
+import jsdom from 'jsdom';
 
 import { SchemaDataType } from './types';
 
 const getAuthor = (html: string): string => {
+  // This will only return false in nodeJS as all modern browsers have a DOMParser
+  if (typeof DOMParser === 'undefined') {
+    return '';
+  }
+
   const parser = new DOMParser();
   const htmldoc = parser.parseFromString(html, 'text/html');
   const authorString = htmldoc.querySelector('h5');
@@ -17,17 +23,23 @@ const getAuthor = (html: string): string => {
   return '';
 };
 
+const cleanBody = (body: string): string => body.replace(/"/g, "'");
+
 export const getSchemaData = (post: any): SchemaDataType => {
   const date = new Date(post.date);
   const formatted_date = date.getFullYear() + '-' + date.getMonth() + '-' + date.getDate();
   const author = getAuthor(post.html);
+  const imageURL = post.featured_media
+    ? 'https://blog.komododigital.co.uk' + post.featured_media.source_url
+    : null;
 
   return {
     title: post.title,
+    headline: post.title,
     date: formatted_date,
     author,
-    imageURL: 'https://blog.komododigital.co.uk' + post.featured_media.source_url,
-    body: post.html,
+    imageURL,
+    body: cleanBody(post.html),
     url: window.location.href,
   };
 };
@@ -41,26 +53,49 @@ const SchemaData: React.SFC<Props> = ({ schemaData }) => {
     return null;
   }
 
+  // If no image just use the Komodo Logo
+  const image = schemaData.imageURL
+    ? schemaData.imageURL
+    : `https://www.komododigital.co.uk${schemaData.logo}`;
+
   const authorString = schemaData.author
     ? `
       "author" : {
         "@type" : "Person",
         "name" : "${schemaData.author}"
       },`
-    : '';
+    : `
+      "author" : {
+        "@type" : "Organization",
+        "name" : "Komodo Digital",
+        "logo" : {
+          "@type" : "ImageObject",
+          "url" : "https://www.komododigital.co.uk${schemaData.logo}"
+        }
+      },`;
 
   const schemaDataString = `
     {
       "@context" : "http://schema.org",
       "@type" : "Article",
+      "mainEntityOfPage": {
+         "@type": "WebPage",
+         "@id": "${window.location.href}"
+      },
       "name" : "${schemaData.title}",${authorString}
-      "datePublished" : "${schemaData.title}",
-      "image" : "${schemaData.image}",
-      "articleBody" : "${schemaData.body}"
+      "headline" : "${schemaData.title}",
+      "datePublished" : "${schemaData.date}",
+      "dateModified" : "${schemaData.date}",
+      "image" : "${image}",
+      "articleBody" : "${schemaData.body}",
       "url" : "${schemaData.url}",
       "publisher" : {
         "@type" : "Organization",
-        "name" : "Komodo Digital"
+        "name" : "Komodo Digital",
+        "logo" : {
+          "@type" : "ImageObject",
+          "url" : "https://www.komododigital.co.uk${schemaData.logo}"
+        }
       }
     }
   `;

--- a/src/components/seo/types.ts
+++ b/src/components/seo/types.ts
@@ -2,3 +2,12 @@ export interface PageMeta {
   title: string;
   description: string;
 }
+
+export interface SchemaDataType {
+  title: string;
+  author?: string;
+  date: string;
+  body: string;
+  imageURL?: string;
+  url: string;
+}

--- a/src/components/seo/types.ts
+++ b/src/components/seo/types.ts
@@ -5,9 +5,11 @@ export interface PageMeta {
 
 export interface SchemaDataType {
   title: string;
+  headline: string;
   author?: string;
   date: string;
   body: string;
   imageURL?: string;
   url: string;
+  logo?: string;
 }

--- a/src/pages/_blog.tsx
+++ b/src/pages/_blog.tsx
@@ -10,6 +10,7 @@ import CleanSourceURL from '../utils/clean-source-url';
 import Placeholder from '../assets/images/placeholder.png';
 import Blog from '../templates/blog';
 import { findNode } from '../utils/nodes';
+import { getSchemaData } from '../components/seo/schemaData.tsx';
 
 export default (props) => {
   const post = props.data.allWordpressPost.edges[0].node;
@@ -34,16 +35,21 @@ export default (props) => {
 
   const html = CleanSourceURL(post.content);
 
+  const schemaData = getSchemaData({ ...post, html });
+
+  console.log(schemaData);
+
   const hocProps = {
     html,
     imageSource,
     insights,
-    insightsIntro: (insightsIntro) ? insightsIntro.htmlAst : '',
+    insightsIntro: insightsIntro ? insightsIntro.htmlAst : '',
     title: post.title,
     pageMeta: {
       title: post.yoast.title || post.title,
       description: post.yoast.metadesc || '',
     },
+    schemaData,
     ...props,
   };
 

--- a/src/pages/_blog.tsx
+++ b/src/pages/_blog.tsx
@@ -37,8 +37,6 @@ export default (props) => {
 
   const schemaData = getSchemaData({ ...post, html });
 
-  console.log(schemaData);
-
   const hocProps = {
     html,
     imageSource,

--- a/src/templates/blog.tsx
+++ b/src/templates/blog.tsx
@@ -14,7 +14,7 @@ export default (props) => {
   }).Compiler;
 
   return (
-    <Layout data={props.data} pageMeta={props.pageMeta}>
+    <Layout data={props.data} pageMeta={props.pageMeta} schemaData={props.schemaData}>
       <TitleText
         title={props.title}
         subtitle={`Insights`}

--- a/src/templates/blog.tsx
+++ b/src/templates/blog.tsx
@@ -13,8 +13,10 @@ export default (props) => {
     createElement: React.createElement,
   }).Compiler;
 
+  const schemaData = { ...props.schemaData, logo: props.data.logo.childImageSharp.fixed.src };
+
   return (
-    <Layout data={props.data} pageMeta={props.pageMeta} schemaData={props.schemaData}>
+    <Layout data={props.data} pageMeta={props.pageMeta} schemaData={schemaData}>
       <TitleText
         title={props.title}
         subtitle={`Insights`}


### PR DESCRIPTION
**What this PR does**

* This PR addresses this issue https://trello.com/c/jjcJ0jWV/33-add-schema-markup
* This PR adds schema data to each insights page. The schema defined for each insight post is the schema for an article see here https://schema.org/Article
* A new react component has been created to add schema markup into the head of the page. Only insight pages will use this component.
* Each page has been tested using this https://search.google.com/structured-data/testing-tool/u/0/ to make sure the schema markup is correct and each essential/recommended field has been filled in